### PR TITLE
Release queue auth guard.

### DIFF
--- a/src/redux/createNetworkMiddleware.js
+++ b/src/redux/createNetworkMiddleware.js
@@ -115,7 +115,9 @@ function createNetworkMiddleware({
       next(dismissActionsFromQueue(action.type));
     }
 
-    if (isConnected === true && actionQueue.length > 0) {
+    const authenticated = getState()?.auth?.api?.state === "AUTHENTICATED";
+
+    if (authenticated === true && isConnected === true && actionQueue.length > 0) {
       console.log(`Processing next item from the action queue: actionQueueSize=${actionQueue.length}`);
 
       // Process the next queued action FIFO-style.


### PR DESCRIPTION
It is possible to have items in the action queue when the user is unauthenticated. Prior to this change, the items would be released, retried, and added back to the action queue (due to a 403 response from the API). This change prevents the items from ever being released when the user is unauthenticated. The goal is to prevent items being released, in-flight for a retry, and then never added back to the action queue due to the app terminating.
